### PR TITLE
Use `ArrayVec::push_many_from_slice` to make code safer

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,9 @@ nanos_sdk = { git = "https://github.com/LedgerHQ/ledger-nanos-sdk.git" }
 nanos_ui = { git = "https://github.com/LedgerHQ/ledger-nanos-ui.git" }
 ledger-parser-combinators = { git = "https://github.com/alamgu/ledger-parser-combinators", branch="async-split-take-2" }
 
+[patch."crates-io".arrayvec]
+git = "https://github.com/obsidiansystems/arrayvec"
+branch = "push-many-from-slice"
 [patch."https://github.com/LedgerHQ/ledger-nanos-sdk.git".nanos_sdk]
 git = "https://github.com/alamgu/ledger-nanos-sdk.git"
 branch = "relocating-loader-w-fixes"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -425,8 +425,8 @@ impl Readable for ByteStream {
             while !buffer.is_full() {
                 let block = self.get_current_block().await;
                 let avail = self.slice_from_block(&block);
-                let consuming = core::cmp::min(avail.len(), buffer.remaining_capacity());
-                buffer.try_extend_from_slice(&avail[0..consuming]).ok();
+                let remaining = buffer.push_many_from_slice(&avail).len();
+                let consuming = avail.len() - remaining;
                 self.consume(&*block, consuming);
             }
             buffer.into_inner().unwrap()


### PR DESCRIPTION
We were ignoring potential (even though it shouldn't happen) failure. The new way however is correct by construction.

The `ArrayVec` method is from https://github.com/bluss/arrayvec/pull/237