### PR TITLE
update Ledger Rust SDK deps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,10 +7,10 @@ edition = "2018"
 
 [dependencies]
 arrayvec = { version = "0.7.2", default-features = false }
-ledger-log = { git = "https://github.com/alamgu/ledger-log" }
+ledger-log = { git = "https://github.com/alamgu/ledger-log", branch = "y333/rust_sdk_single_crate" }
 pin-project = "1.0.10"
 ledger_device_sdk = { version = "1.28.0", features=["sys"] }
-ledger-parser-combinators = { git = "https://github.com/alamgu/ledger-parser-combinators", branch="async-split-take-2" }
+ledger-parser-combinators = { git = "https://github.com/alamgu/ledger-parser-combinators", branch="y333/rust_sdk_single_crate" }
 
 [features]
 default = []
@@ -18,8 +18,3 @@ prompts = []
 
 [patch.crates-io]
 ledger_device_sdk = {git = "https://github.com/LedgerHQ/ledger-device-rust-sdk.git" }
-
-[patch."https://github.com/alamgu/ledger-log"]
-ledger-log = { path = "../../alamgu/ledger-log" }
-[patch."https://github.com/alamgu/ledger-parser-combinators"]
-ledger-parser-combinators = { path = "../../alamgu/ledger-parser-combinators" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,10 +9,17 @@ edition = "2018"
 arrayvec = { version = "0.7.2", default-features = false }
 ledger-log = { git = "https://github.com/alamgu/ledger-log" }
 pin-project = "1.0.10"
-ledger_device_sdk = "1.4.3"
-ledger_secure_sdk_sys = "1.1.0"
+ledger_device_sdk = { version = "1.28.0", features=["sys"] }
 ledger-parser-combinators = { git = "https://github.com/alamgu/ledger-parser-combinators", branch="async-split-take-2" }
 
 [features]
 default = []
 prompts = []
+
+[patch.crates-io]
+ledger_device_sdk = {git = "https://github.com/LedgerHQ/ledger-device-rust-sdk.git" }
+
+[patch."https://github.com/alamgu/ledger-log"]
+ledger-log = { path = "../../alamgu/ledger-log" }
+[patch."https://github.com/alamgu/ledger-parser-combinators"]
+ledger-parser-combinators = { path = "../../alamgu/ledger-parser-combinators" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 
 [dependencies]
 arrayvec = { version = "0.7.2", default-features = false }
-ledger-log = { git = "https://github.com/alamgu/ledger-log", branch = "y333/rust_sdk_single_crate" }
+ledger-log = { git = "https://github.com/alamgu/ledger-log" }
 pin-project = "1.0.10"
 ledger_device_sdk = { version = "1.29.0", features=["sys"] }
 ledger-parser-combinators = { git = "https://github.com/alamgu/ledger-parser-combinators", branch="y333/rust_sdk_single_crate" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ arrayvec = { version = "0.7.2", default-features = false }
 ledger-log = { git = "https://github.com/alamgu/ledger-log" }
 pin-project = "1.0.10"
 ledger_device_sdk = { version = "1.29.0", features=["sys"] }
-ledger-parser-combinators = { git = "https://github.com/alamgu/ledger-parser-combinators", branch="y333/rust_sdk_single_crate" }
+ledger-parser-combinators = { git = "https://github.com/alamgu/ledger-parser-combinators" }
 
 [features]
 default = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ arrayvec = { version = "0.7.2", default-features = false }
 ledger-log = { git = "https://github.com/alamgu/ledger-log" }
 pin-project = "1.0.10"
 ledger_device_sdk = { version = "1.29.0", features=["sys"] }
-ledger-parser-combinators = { git = "https://github.com/alamgu/ledger-parser-combinators" }
+ledger-parser-combinators = { git = "https://github.com/alamgu/ledger-parser-combinators", branch="async-split-take-2" }
 
 [features]
 default = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,12 +9,9 @@ edition = "2018"
 arrayvec = { version = "0.7.2", default-features = false }
 ledger-log = { git = "https://github.com/alamgu/ledger-log", branch = "y333/rust_sdk_single_crate" }
 pin-project = "1.0.10"
-ledger_device_sdk = { version = "1.28.0", features=["sys"] }
+ledger_device_sdk = { version = "1.29.0", features=["sys"] }
 ledger-parser-combinators = { git = "https://github.com/alamgu/ledger-parser-combinators", branch="y333/rust_sdk_single_crate" }
 
 [features]
 default = []
 prompts = []
-
-[patch.crates-io]
-ledger_device_sdk = {git = "https://github.com/LedgerHQ/ledger-device-rust-sdk.git" }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -84,7 +84,7 @@ use core::future::Future;
 use core::pin::Pin;
 use ledger_log::*;
 use ledger_parser_combinators::async_parser::{reject, Readable, UnwrappableReadable, REJECTED_CODE};
-use ledger_secure_sdk_sys::*;
+use ledger_device_sdk::sys::*;
 use ledger_device_sdk::io;
 use ledger_device_sdk::io::SyscallError;
 


### PR DESCRIPTION
This PR updates the Ledger Rust SDK dependencies: sys crate is now available through the `sys` feature.
PR should be merged when the new `ledger_device_sdk` crate ( version > 1.28) will be published on crates.io. 